### PR TITLE
feat: introduce gwyneth protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ version = "0.1.0"
 dependencies = [
  "auto_impl",
  "revm",
+ "revm-primitives",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,8 +229,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c35fc4b03ace65001676358ffbbaefe2a2b27ee50fe777c345082c7c888be8"
+source = "git+https://github.com/taikoxyz/alloy-core.git?branch=gwyneth#ac139f13bc2a09a45c0928dd780d30b32fc601de"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -1333,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1753,7 +1752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2114,6 +2113,15 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "gwyneth-revm"
+version = "0.1.0"
+dependencies = [
+ "auto_impl",
+ "revm",
+ "serde",
 ]
 
 [[package]]
@@ -2535,7 +2543,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4047,7 +4055,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4575,7 +4583,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5100,7 +5108,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ members = [
     "examples/erc20_gas",
     "examples/my_evm",
     "examples/custom_opcodes",
+
+    # gwyneth
+    "crates/gwyneth",
 ]
 resolver = "2"
 default-members = ["crates/revm"]
@@ -167,3 +170,7 @@ inherits = "profiling"
 [profile.ethtests]
 inherits = "test"
 opt-level = 3
+
+
+[patch.crates-io]
+alloy-primitives = { git = "https://github.com/taikoxyz/alloy-core.git", branch = "gwyneth" }

--- a/crates/gwyneth/Cargo.toml
+++ b/crates/gwyneth/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace = true
 
 [dependencies]
 revm.workspace = true
+primitives.workspace = true
 auto_impl.workspace = true
 
 # optional

--- a/crates/gwyneth/Cargo.toml
+++ b/crates/gwyneth/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "gwyneth-revm"
+version = "0.1.0"
+license.workspace = true
+authors.workspace = true
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+edition.workspace = true
+
+[dependencies]
+revm.workspace = true
+auto_impl.workspace = true
+
+# optional
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
+
+[lints]
+workspace = true
+
+[features]
+serde = ["dep:serde", "revm/serde"]

--- a/crates/gwyneth/src/cfg.rs
+++ b/crates/gwyneth/src/cfg.rs
@@ -1,0 +1,7 @@
+use auto_impl::auto_impl;
+use revm::context::Cfg;
+
+#[auto_impl(&, &mut, Box, Arc)]
+pub trait CfgExt: Cfg {
+    fn allow_mocking(&self) -> bool;
+}

--- a/crates/gwyneth/src/context.rs
+++ b/crates/gwyneth/src/context.rs
@@ -1,10 +1,10 @@
 use crate::cfg::CfgExt;
 use revm::context::{Cfg, ContextTr};
 
-// Type alias for Optimism context
+// Type alias for Gwyneth context
 pub trait GwynethContextTr: ContextTr<Cfg: CfgExt, Chain = GwynethContext> {}
 
-///
+/// Gwyneth special context
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GwynethContext {
     pub xcall_options: Option<crate::xcall::XCallOptions>,

--- a/crates/gwyneth/src/context.rs
+++ b/crates/gwyneth/src/context.rs
@@ -1,5 +1,5 @@
 use crate::cfg::CfgExt;
-use revm::context::{Cfg, ContextTr};
+use revm::context::ContextTr;
 
 // Type alias for Gwyneth context
 pub trait GwynethContextTr: ContextTr<Cfg: CfgExt, Chain = GwynethContext> {}

--- a/crates/gwyneth/src/context.rs
+++ b/crates/gwyneth/src/context.rs
@@ -7,5 +7,6 @@ pub trait GwynethContextTr: ContextTr<Cfg: CfgExt, Chain = GwynethContext> {}
 /// Gwyneth special context
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GwynethContext {
+    /// xcall options setting by the precompile
     pub xcall_options: Option<crate::xcall::XCallOptions>,
 }

--- a/crates/gwyneth/src/context.rs
+++ b/crates/gwyneth/src/context.rs
@@ -1,0 +1,11 @@
+use crate::cfg::CfgExt;
+use revm::context::{Cfg, ContextTr};
+
+// Type alias for Optimism context
+pub trait GwynethContextTr: ContextTr<Cfg: CfgExt, Chain = GwynethContext> {}
+
+///
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GwynethContext {
+    pub xcall_options: Option<crate::xcall::XCallOptions>,
+}

--- a/crates/gwyneth/src/evm.rs
+++ b/crates/gwyneth/src/evm.rs
@@ -1,7 +1,4 @@
-use crate::{
-    interpreter::InterpreterExtend,
-    precompiles::{GwynethPrecompiles, OpPrecompiles},
-};
+use crate::precompiles::GwynethPrecompiles;
 use revm::{
     context::{ContextSetters, Evm},
     context_interface::ContextTr,
@@ -26,25 +23,8 @@ impl<CTX: ContextTr, INSP>
             ctx,
             inspector,
             instruction: EthInstructions::new_mainnet(),
-            precompiles: OpPrecompiles::default(),
+            precompiles: GwynethPrecompiles::default(),
         })
-    }
-}
-
-impl<CTX, INSP, I, P> GwynethEvm<CTX, INSP, I, P> {
-    /// Consumed self and returns a new Evm type with given Inspector.
-    pub fn with_inspector<OINSP>(self, inspector: OINSP) -> OpEvm<CTX, OINSP, I, P> {
-        OpEvm(self.0.with_inspector(inspector))
-    }
-
-    /// Consumes self and returns a new Evm type with given Precompiles.
-    pub fn with_precompiles<OP>(self, precompiles: OP) -> OpEvm<CTX, INSP, I, OP> {
-        OpEvm(self.0.with_precompiles(precompiles))
-    }
-
-    /// Consumes self and returns the inner Inspector.
-    pub fn into_inspector(self) -> INSP {
-        self.0.into_inspector()
     }
 }
 

--- a/crates/gwyneth/src/evm.rs
+++ b/crates/gwyneth/src/evm.rs
@@ -1,28 +1,32 @@
-use crate::precompiles::GwynethPrecompiles;
+use crate::{
+    context::GwynethContextTr, instructions::GwynethInstructions, precompiles::GwynethPrecompiles,
+};
 use revm::{
     context::{ContextSetters, Evm},
     context_interface::ContextTr,
-    handler::{
-        instructions::{EthInstructions, InstructionProvider},
-        EvmTr, PrecompileProvider,
-    },
+    handler::{instructions::InstructionProvider, EvmTr, PrecompileProvider},
     inspector::{InspectorEvmTr, JournalExt},
-    interpreter::{interpreter::EthInterpreter, Interpreter, InterpreterAction, InterpreterTypes},
+    interpreter::{
+        interpreter::EthInterpreter, Host, Interpreter, InterpreterAction, InterpreterTypes,
+    },
     Inspector,
 };
 
-pub struct GwynethEvm<CTX, INSP, I = EthInstructions<EthInterpreter, CTX>, P = GwynethPrecompiles>(
-    pub Evm<CTX, INSP, I, P>,
-);
+pub struct GwynethEvm<
+    CTX,
+    INSP,
+    I = GwynethInstructions<EthInterpreter, CTX>,
+    P = GwynethPrecompiles,
+>(pub Evm<CTX, INSP, I, P>);
 
-impl<CTX: ContextTr, INSP>
-    GwynethEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, GwynethPrecompiles>
+impl<CTX: GwynethContextTr + Host, INSP>
+    GwynethEvm<CTX, INSP, GwynethInstructions<EthInterpreter, CTX>, GwynethPrecompiles>
 {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
         Self(Evm {
             ctx,
             inspector,
-            instruction: EthInstructions::new_mainnet(),
+            instruction: GwynethInstructions::new_mainnet(),
             precompiles: GwynethPrecompiles::default(),
         })
     }

--- a/crates/gwyneth/src/evm.rs
+++ b/crates/gwyneth/src/evm.rs
@@ -1,0 +1,122 @@
+use crate::{
+    interpreter::InterpreterExtend,
+    precompiles::{GwynethPrecompiles, OpPrecompiles},
+};
+use revm::{
+    context::{ContextSetters, Evm},
+    context_interface::ContextTr,
+    handler::{
+        instructions::{EthInstructions, InstructionProvider},
+        EvmTr, PrecompileProvider,
+    },
+    inspector::{InspectorEvmTr, JournalExt},
+    interpreter::{interpreter::EthInterpreter, Interpreter, InterpreterAction, InterpreterTypes},
+    Inspector,
+};
+
+pub struct GwynethEvm<CTX, INSP, I = EthInstructions<EthInterpreter, CTX>, P = GwynethPrecompiles>(
+    pub Evm<CTX, INSP, I, P>,
+);
+
+impl<CTX: ContextTr, INSP>
+    GwynethEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, GwynethPrecompiles>
+{
+    pub fn new(ctx: CTX, inspector: INSP) -> Self {
+        Self(Evm {
+            ctx,
+            inspector,
+            instruction: EthInstructions::new_mainnet(),
+            precompiles: OpPrecompiles::default(),
+        })
+    }
+}
+
+impl<CTX, INSP, I, P> GwynethEvm<CTX, INSP, I, P> {
+    /// Consumed self and returns a new Evm type with given Inspector.
+    pub fn with_inspector<OINSP>(self, inspector: OINSP) -> OpEvm<CTX, OINSP, I, P> {
+        OpEvm(self.0.with_inspector(inspector))
+    }
+
+    /// Consumes self and returns a new Evm type with given Precompiles.
+    pub fn with_precompiles<OP>(self, precompiles: OP) -> OpEvm<CTX, INSP, I, OP> {
+        OpEvm(self.0.with_precompiles(precompiles))
+    }
+
+    /// Consumes self and returns the inner Inspector.
+    pub fn into_inspector(self) -> INSP {
+        self.0.into_inspector()
+    }
+}
+
+impl<CTX, INSP, I, P> InspectorEvmTr for GwynethEvm<CTX, INSP, I, P>
+where
+    CTX: ContextTr<Journal: JournalExt> + ContextSetters,
+    I: InstructionProvider<
+        Context = CTX,
+        InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
+    >,
+    P: PrecompileProvider<CTX>,
+    INSP: Inspector<CTX, I::InterpreterTypes>,
+{
+    type Inspector = INSP;
+
+    fn inspector(&mut self) -> &mut Self::Inspector {
+        &mut self.0.inspector
+    }
+
+    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
+        (&mut self.0.ctx, &mut self.0.inspector)
+    }
+
+    fn run_inspect_interpreter(
+        &mut self,
+        interpreter: &mut Interpreter<
+            <Self::Instructions as InstructionProvider>::InterpreterTypes,
+        >,
+    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
+    {
+        self.0.run_inspect_interpreter(interpreter)
+    }
+}
+
+impl<CTX, INSP, I, P> EvmTr for GwynethEvm<CTX, INSP, I, P>
+where
+    CTX: ContextTr,
+    I: InstructionProvider<
+        Context = CTX,
+        InterpreterTypes: InterpreterTypes<Output = InterpreterAction>,
+    >,
+    P: PrecompileProvider<CTX>,
+{
+    type Context = CTX;
+    type Instructions = I;
+    type Precompiles = P;
+
+    fn run_interpreter(
+        &mut self,
+        interpreter: &mut Interpreter<
+            <Self::Instructions as InstructionProvider>::InterpreterTypes,
+        >,
+    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
+    {
+        let context = &mut self.0.ctx;
+        let instructions = &mut self.0.instruction;
+        interpreter.run_plain(instructions.instruction_table(), context)
+    }
+
+    fn ctx(&mut self) -> &mut Self::Context {
+        &mut self.0.ctx
+    }
+
+    fn ctx_ref(&self) -> &Self::Context {
+        &self.0.ctx
+    }
+
+    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
+        (&mut self.0.ctx, &mut self.0.instruction)
+    }
+
+    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
+        (&mut self.0.ctx, &mut self.0.precompiles)
+    }
+}

--- a/crates/gwyneth/src/instructions.rs
+++ b/crates/gwyneth/src/instructions.rs
@@ -59,7 +59,16 @@ mod hack {
         popn!([local_gas_limit, to, value], context.interpreter);
         let to = to.into_address();
         // Get the target
-        let call_targets = apply_xcall_options::<WIRE, H>(context, to, false, false);
+
+        let call_targets = apply_xcall_options::<WIRE, H>(
+            InstructionContext {
+                host: context.host,
+                interpreter: context.interpreter,
+            },
+            to,
+            false,
+            false,
+        );
         // Max gas limit is not possible in real ethereum situation.
         let local_gas_limit = u64::try_from(local_gas_limit).unwrap_or(u64::MAX);
 

--- a/crates/gwyneth/src/instructions.rs
+++ b/crates/gwyneth/src/instructions.rs
@@ -158,7 +158,7 @@ mod hack {
     ) -> CallTargets {
         //println!("apply_call_options {:?}", interpreter.call_options);
         let chain_id = context.host.cfg().chain_id();
-        let (xcall_options, mut to) = match context.host.chain().xcall_options.clone() {
+        let (xcall_options, mut to) = match context.host.chain().xcall_options.take() {
             Some(xcall_options) => {
                 println!("apply_call_options {:?}", xcall_options);
                 // In delegate call, the caller & target address remains on the same chain
@@ -206,10 +206,6 @@ mod hack {
         };
 
         //println!("call targets {:?}", call_targets);
-
-        // Consume the values
-        context.host.chain().xcall_options = None;
-
         call_targets
     }
 }

--- a/crates/gwyneth/src/instructions.rs
+++ b/crates/gwyneth/src/instructions.rs
@@ -1,0 +1,206 @@
+use revm::{
+    bytecode::opcode::CALL,
+    handler::instructions::{EthInstructions, InstructionProvider},
+    interpreter::{Host, InstructionTable, InterpreterTypes},
+};
+
+use crate::context::GwynethContextTr;
+
+pub struct GwynethInstructions<WIRE: InterpreterTypes, HOST> {
+    inner: EthInstructions<WIRE, HOST>,
+}
+
+impl<WIRE, HOST> GwynethInstructions<WIRE, HOST>
+where
+    WIRE: InterpreterTypes,
+    HOST: GwynethContextTr + Host,
+{
+    /// Returns `EthInstructions` with mainnet spec.
+    pub fn new_mainnet() -> Self {
+        let mut inner = EthInstructions::new_mainnet();
+        inner.insert_instruction(CALL, hack::call);
+        GwynethInstructions { inner }
+    }
+}
+
+impl<IT, CTX> InstructionProvider for GwynethInstructions<IT, CTX>
+where
+    IT: InterpreterTypes,
+    CTX: Host,
+{
+    type InterpreterTypes = IT;
+    type Context = CTX;
+
+    fn instruction_table(&self) -> &InstructionTable<Self::InterpreterTypes, Self::Context> {
+        &self.inner.instruction_table
+    }
+}
+
+mod hack {
+    use crate::{context::GwynethContextTr, xcall::XCallOptions};
+    use revm::{
+        context::Cfg,
+        interpreter::{
+            gas,
+            instructions::{
+                contract::{calc_call_gas, get_memory_input_and_out_ranges},
+                utility::IntoAddress,
+            },
+            interpreter_types::{InputsTr, LoopControl, RuntimeFlag, StackTr},
+            popn, CallInput, CallInputs, CallScheme, CallValue, FrameInput, Host,
+            InstructionContext, InstructionResult, InterpreterAction, InterpreterTypes,
+        },
+        primitives::Address,
+    };
+
+    pub fn call<WIRE: InterpreterTypes, H: GwynethContextTr + Host>(
+        context: InstructionContext<'_, H, WIRE>,
+    ) {
+        popn!([local_gas_limit, to, value], context.interpreter);
+        let to = to.into_address();
+        // Get the target
+        let call_targets = apply_xcall_options::<WIRE, H>(context, to, false, false);
+        // Max gas limit is not possible in real ethereum situation.
+        let local_gas_limit = u64::try_from(local_gas_limit).unwrap_or(u64::MAX);
+
+        let has_transfer = !value.is_zero();
+        if context.interpreter.runtime_flag.is_static() && has_transfer {
+            context
+                .interpreter
+                .control
+                .set_instruction_result(InstructionResult::CallNotAllowedInsideStatic);
+            return;
+        }
+
+        let Some((input, return_memory_offset)) =
+            get_memory_input_and_out_ranges(context.interpreter)
+        else {
+            return;
+        };
+
+        let Some(account_load) = context
+            .host
+            .load_account_delegated(call_targets.bytecode_address)
+        else {
+            context
+                .interpreter
+                .control
+                .set_instruction_result(InstructionResult::FatalExternalError);
+            return;
+        };
+
+        let Some(mut gas_limit) = calc_call_gas(
+            context.interpreter,
+            account_load,
+            has_transfer,
+            local_gas_limit,
+        ) else {
+            return;
+        };
+
+        gas!(context.interpreter, gas_limit);
+
+        // Add call stipend if there is value to be transferred.
+        if has_transfer {
+            gas_limit = gas_limit.saturating_add(gas::CALL_STIPEND);
+        }
+
+        // Call host to interact with target contract
+        context.interpreter.control.set_next_action(
+            InterpreterAction::NewFrame(FrameInput::Call(Box::new(CallInputs {
+                input: CallInput::SharedBuffer(input),
+                gas_limit,
+                target_address: call_targets.target_address,
+                caller: call_targets.caller,
+                bytecode_address: call_targets.bytecode_address,
+                value: CallValue::Transfer(value),
+                scheme: CallScheme::Call,
+                is_static: context.interpreter.runtime_flag.is_static(),
+                is_eof: false,
+                return_memory_offset,
+            }))),
+            InstructionResult::CallOrCreate,
+        );
+    }
+
+    #[derive(Debug, Clone)]
+    struct CallTargets {
+        /// The account address of bytecode that is going to be executed.
+        ///
+        /// Previously `context.code_address`.
+        pub bytecode_address: Address,
+        /// Target address, this account storage is going to be modified.
+        ///
+        /// Previously `context.address`.
+        pub target_address: Address,
+        /// This caller is invoking the call.
+        ///
+        /// Previously `context.caller`.
+        pub caller: Address,
+    }
+
+    /// Collects call options for this CAL
+    /// This consumes the data from the PREVIOUS call into the XCALLOPTIONS precompile.
+    fn apply_xcall_options<WIRE: InterpreterTypes, H: GwynethContextTr + Host + ?Sized>(
+        context: InstructionContext<'_, H, WIRE>,
+        mut to: Address,
+        delegate: bool,
+        code: bool,
+    ) -> CallTargets {
+        //println!("apply_call_options {:?}", interpreter.call_options);
+        let chain_id = context.host.cfg().chain_id();
+        let (xcall_options, mut to) = match context.host.chain().xcall_options.clone() {
+            Some(xcall_options) => {
+                println!("apply_call_options {:?}", xcall_options);
+                // In delegate call, the caller & target address remains on the same chain
+                // Otherwise set to the other chain.
+                if delegate {
+                    to.set_chain_id(chain_id);
+                } else {
+                    to.set_chain_id(xcall_options.chain_id);
+                };
+                (xcall_options, to)
+            }
+            None => {
+                to.set_chain_id(chain_id);
+                (
+                    XCallOptions {
+                        chain_id,
+                        sandbox: false,
+                        tx_origin: context.host.caller(),
+                        msg_sender: context.interpreter.input.target_address(),
+                        block_hash: None,
+                        proof: Vec::new(),
+                    },
+                    to,
+                )
+            }
+        };
+
+        let call_targets = CallTargets {
+            target_address: if delegate || code {
+                xcall_options.msg_sender
+            } else {
+                to
+            },
+            caller: if delegate {
+                context.interpreter.input.caller_address()
+            } else {
+                xcall_options.msg_sender
+            },
+            bytecode_address: if delegate {
+                to.set_chain_id(xcall_options.chain_id);
+                to
+            } else {
+                to
+            },
+        };
+
+        //println!("call targets {:?}", call_targets);
+
+        // Consume the values
+        context.host.chain().xcall_options = None;
+
+        call_targets
+    }
+}

--- a/crates/gwyneth/src/instructions.rs
+++ b/crates/gwyneth/src/instructions.rs
@@ -44,7 +44,7 @@ mod hack {
     use revm::{
         context::Cfg,
         interpreter::{
-            gas,
+            check, gas,
             instructions::{
                 contract::{calc_call_gas, get_memory_input_and_out_ranges},
                 utility::IntoAddress,
@@ -53,10 +53,10 @@ mod hack {
             popn, CallInput, CallInputs, CallScheme, CallValue, FrameInput, Host,
             InstructionContext, InstructionResult, InterpreterAction, InterpreterTypes,
         },
-        primitives::Address,
+        primitives::{Address, B256, U256},
     };
 
-    pub fn call<WIRE: InterpreterTypes, H: GwynethContextTr + Host>(
+    pub fn call<WIRE: InterpreterTypes, H: GwynethContextTr + Host + ?Sized>(
         context: InstructionContext<'_, H, WIRE>,
     ) {
         popn!([local_gas_limit, to, value], context.interpreter);
@@ -134,7 +134,7 @@ mod hack {
         );
     }
 
-    pub fn call_code<WIRE: InterpreterTypes, H: Host + ?Sized>(
+    pub fn call_code<WIRE: InterpreterTypes, H: GwynethContextTr + Host + ?Sized>(
         context: InstructionContext<'_, H, WIRE>,
     ) {
         popn!([local_gas_limit, to, value], context.interpreter);
@@ -203,7 +203,7 @@ mod hack {
         );
     }
 
-    pub fn delegate_call<WIRE: InterpreterTypes, H: Host + ?Sized>(
+    pub fn delegate_call<WIRE: InterpreterTypes, H: GwynethContextTr + Host + ?Sized>(
         context: InstructionContext<'_, H, WIRE>,
     ) {
         check!(context.interpreter, HOMESTEAD);
@@ -266,7 +266,7 @@ mod hack {
         );
     }
 
-    pub fn static_call<WIRE: InterpreterTypes, H: Host + ?Sized>(
+    pub fn static_call<WIRE: InterpreterTypes, H: GwynethContextTr + Host + ?Sized>(
         context: InstructionContext<'_, H, WIRE>,
     ) {
         check!(context.interpreter, BYZANTIUM);

--- a/crates/gwyneth/src/lib.rs
+++ b/crates/gwyneth/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cfg;
 pub mod context;
 pub mod evm;
+pub mod instructions;
 pub mod precompiles;
 pub mod xcall;

--- a/crates/gwyneth/src/lib.rs
+++ b/crates/gwyneth/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod cfg;
+pub mod context;
+pub mod evm;
+pub mod precompiles;
+pub mod xcall;

--- a/crates/gwyneth/src/precompiles.rs
+++ b/crates/gwyneth/src/precompiles.rs
@@ -1,15 +1,14 @@
 use revm::{
     context::{Cfg, LocalContextTr},
-    context_interface::ContextTr,
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInput, Gas, InputsImpl, InstructionResult, InterpreterResult},
-    precompile::{PrecompileSpecId, Precompiles},
+    precompile::{PrecompileError, PrecompileSpecId, Precompiles},
     primitives::{hardfork::SpecId, Address, Bytes},
 };
 use std::boxed::Box;
 use std::string::String;
 
-use crate::{context::GwynethContextTr, interpreter::GwynethInterpreterResult, xcall};
+use crate::{context::GwynethContextTr, xcall};
 
 // Gwyneth precompile provider
 #[derive(Default, Debug, Clone)]
@@ -60,7 +59,7 @@ impl<CTX: GwynethContextTr> PrecompileProvider<CTX> for GwynethPrecompiles {
         is_static: bool,
         gas_limit: u64,
     ) -> Result<Option<Self::Output>, String> {
-        if self.is_in_berlin() && address == xcall::XCALL_ADDRESS {
+        if self.is_in_berlin() && *address == xcall::XCALL_ADDRESS {
             let mut result = InterpreterResult {
                 result: InstructionResult::Return,
                 gas: Gas::new(gas_limit),

--- a/crates/gwyneth/src/precompiles.rs
+++ b/crates/gwyneth/src/precompiles.rs
@@ -29,12 +29,6 @@ impl GwynethPrecompiles {
         }
     }
 
-    // Precompiles getter.
-    #[inline]
-    pub fn precompiles(&self) -> &'static Precompiles {
-        self.inner.precompiles
-    }
-
     /// Check if the current spec is BERLIN.
     /// We need attach the xcall precompile in BERLIN fork
     pub fn is_in_berlin(&self) -> bool {

--- a/crates/gwyneth/src/precompiles.rs
+++ b/crates/gwyneth/src/precompiles.rs
@@ -1,7 +1,7 @@
 use revm::{
-    context::{Cfg, LocalContextTr},
+    context::Cfg,
     handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::{CallInput, Gas, InputsImpl, InstructionResult, InterpreterResult},
+    interpreter::{Gas, InputsImpl, InstructionResult, InterpreterResult},
     precompile::{PrecompileError, PrecompileSpecId, Precompiles},
     primitives::{hardfork::SpecId, Address, Bytes},
 };
@@ -65,21 +65,7 @@ impl<CTX: GwynethContextTr> PrecompileProvider<CTX> for GwynethPrecompiles {
                 gas: Gas::new(gas_limit),
                 output: Bytes::new(),
             };
-
-            let r;
-            let input_bytes = match &inputs.input {
-                CallInput::SharedBuffer(range) => {
-                    if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
-                        r = slice;
-                        r.as_ref()
-                    } else {
-                        &[]
-                    }
-                }
-                CallInput::Bytes(bytes) => bytes.0.iter().as_slice(),
-            };
-
-            match xcall::run_xcall(input_bytes, gas_limit, context, inputs.caller_address) {
+            match xcall::run_xcall(inputs, gas_limit, context, inputs.caller_address) {
                 Ok(output) => {
                     let underflow = result.gas.record_cost(output.gas_used);
                     assert!(underflow, "Gas underflow is not possible");

--- a/crates/gwyneth/src/precompiles.rs
+++ b/crates/gwyneth/src/precompiles.rs
@@ -53,7 +53,7 @@ impl<CTX: GwynethContextTr> PrecompileProvider<CTX> for GwynethPrecompiles {
         is_static: bool,
         gas_limit: u64,
     ) -> Result<Option<Self::Output>, String> {
-        if self.is_in_berlin() && *address == xcall::XCALL_ADDRESS {
+        if self.is_in_berlin() && address == &xcall::XCALL_ADDRESS {
             let mut result = InterpreterResult {
                 result: InstructionResult::Return,
                 gas: Gas::new(gas_limit),
@@ -83,11 +83,18 @@ impl<CTX: GwynethContextTr> PrecompileProvider<CTX> for GwynethPrecompiles {
 
     #[inline]
     fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        self.inner.warm_addresses()
+        Box::new(
+            self.inner
+                .warm_addresses()
+                .chain(std::iter::once(xcall::XCALL_ADDRESS)),
+        )
     }
 
     #[inline]
     fn contains(&self, address: &Address) -> bool {
+        if address == &xcall::XCALL_ADDRESS {
+            return self.is_in_berlin();
+        }
         self.inner.contains(address)
     }
 }

--- a/crates/gwyneth/src/precompiles.rs
+++ b/crates/gwyneth/src/precompiles.rs
@@ -1,0 +1,114 @@
+use revm::{
+    context::{Cfg, LocalContextTr},
+    context_interface::ContextTr,
+    handler::{EthPrecompiles, PrecompileProvider},
+    interpreter::{CallInput, Gas, InputsImpl, InstructionResult, InterpreterResult},
+    precompile::{PrecompileSpecId, Precompiles},
+    primitives::{hardfork::SpecId, Address, Bytes},
+};
+use std::boxed::Box;
+use std::string::String;
+
+use crate::{context::GwynethContextTr, interpreter::GwynethInterpreterResult, xcall};
+
+// Gwyneth precompile provider
+#[derive(Default, Debug, Clone)]
+pub struct GwynethPrecompiles {
+    /// Inner precompile provider is same as Ethereums.
+    inner: EthPrecompiles,
+}
+
+impl GwynethPrecompiles {
+    /// Create a new precompile provider with the given OpSpec.
+    #[inline]
+    pub fn new_with_spec(spec: SpecId) -> Self {
+        Self {
+            inner: EthPrecompiles {
+                precompiles: Precompiles::new(PrecompileSpecId::from_spec_id(spec)),
+                spec,
+            },
+        }
+    }
+
+    // Precompiles getter.
+    #[inline]
+    pub fn precompiles(&self) -> &'static Precompiles {
+        self.inner.precompiles
+    }
+
+    /// Check if the current spec is BERLIN.
+    /// We need attach the xcall precompile in BERLIN fork
+    pub fn is_in_berlin(&self) -> bool {
+        self.inner.spec.is_enabled_in(SpecId::BERLIN)
+    }
+}
+
+impl<CTX: GwynethContextTr> PrecompileProvider<CTX> for GwynethPrecompiles {
+    type Output = InterpreterResult;
+
+    #[inline]
+    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
+        <EthPrecompiles as PrecompileProvider<CTX>>::set_spec(&mut self.inner, spec)
+    }
+
+    #[inline]
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        address: &Address,
+        inputs: &InputsImpl,
+        is_static: bool,
+        gas_limit: u64,
+    ) -> Result<Option<Self::Output>, String> {
+        if self.is_in_berlin() && address == xcall::XCALL_ADDRESS {
+            let mut result = InterpreterResult {
+                result: InstructionResult::Return,
+                gas: Gas::new(gas_limit),
+                output: Bytes::new(),
+            };
+
+            let r;
+            let input_bytes = match &inputs.input {
+                CallInput::SharedBuffer(range) => {
+                    if let Some(slice) = context.local().shared_memory_buffer_slice(range.clone()) {
+                        r = slice;
+                        r.as_ref()
+                    } else {
+                        &[]
+                    }
+                }
+                CallInput::Bytes(bytes) => bytes.0.iter().as_slice(),
+            };
+
+            match xcall::run_xcall(input_bytes, gas_limit, context, inputs.caller_address) {
+                Ok(output) => {
+                    let underflow = result.gas.record_cost(output.gas_used);
+                    assert!(underflow, "Gas underflow is not possible");
+                    result.result = InstructionResult::Return;
+                    result.output = output.bytes;
+                }
+                Err(PrecompileError::Fatal(e)) => return Err(e),
+                Err(e) => {
+                    result.result = if e.is_oog() {
+                        InstructionResult::PrecompileOOG
+                    } else {
+                        InstructionResult::PrecompileError
+                    };
+                }
+            }
+            return Ok(Some(result));
+        }
+        self.inner
+            .run(context, address, inputs, is_static, gas_limit)
+    }
+
+    #[inline]
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        self.inner.warm_addresses()
+    }
+
+    #[inline]
+    fn contains(&self, address: &Address) -> bool {
+        self.inner.contains(address)
+    }
+}

--- a/crates/gwyneth/src/xcall.rs
+++ b/crates/gwyneth/src/xcall.rs
@@ -1,6 +1,6 @@
 use crate::{cfg::CfgExt, context::GwynethContextTr};
 use revm::{
-    context::{ContextTr, Transaction},
+    context::Transaction,
     precompile::{u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult},
     primitives::{Address, Bytes, FixedBytes, B256},
 };
@@ -33,7 +33,7 @@ pub struct XCallOptions {
 pub fn run_xcall<CTX: GwynethContextTr>(
     input: &[u8],
     _gas_limit: u64,
-    ctx: &CTX,
+    ctx: &mut CTX,
     caller: Address,
 ) -> PrecompileResult {
     println!("  xcalloptions_run: {}, {:?}", input.len(), input);
@@ -73,7 +73,7 @@ pub fn run_xcall<CTX: GwynethContextTr>(
     }
 
     // Set the call options
-    *ctx.chain().xcall_options = Some(XCallOptions {
+    *(&mut ctx.chain().xcall_options) = Some(XCallOptions {
         chain_id,
         sandbox,
         tx_origin,
@@ -81,7 +81,7 @@ pub fn run_xcall<CTX: GwynethContextTr>(
         block_hash,
         proof: proof.to_vec(),
     });
-    println!("  CallOptions: {:?}", xcall_options);
+    println!("  CallOptions: {:?}", ctx.chain().xcall_options);
 
     Ok(PrecompileOutput::new(
         0,

--- a/crates/gwyneth/src/xcall.rs
+++ b/crates/gwyneth/src/xcall.rs
@@ -1,0 +1,90 @@
+use crate::{cfg::CfgExt, context::GwynethContextTr};
+use revm::{
+    context::{ContextTr, Transaction},
+    precompile::{u64_to_address, PrecompileError, PrecompileOutput, PrecompileResult},
+    primitives::{Address, Bytes, FixedBytes, B256},
+};
+
+/// The address of the xcall precompile
+pub const XCALL_ADDRESS: Address = u64_to_address(1234);
+
+const XCALL_INVALID_INPUT_LENGTH: &str = "XCallInvalidInputLength";
+const XCALL_INVALID_VERSION: &str = "XCallInvalidVersion";
+const XCALL_INVALID_ORIGIN: &str = "XCallInvalidOrigin";
+
+/// The options for the xcall precompile
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct XCallOptions {
+    /// The target chain id
+    pub chain_id: u64,
+    /// If the call needs to persist state changes or not
+    pub sandbox: bool,
+    /// Mocked `tx.origin`
+    pub tx_origin: Address,
+    /// Mocked `msg.sender`
+    pub msg_sender: Address,
+    /// The block hash to execute against (None will execute against the latest known blockhash)
+    pub block_hash: Option<B256>,
+    /// The data necessary to execute the call
+    pub proof: Vec<u8>,
+}
+
+/// Run the xcall precompile.
+pub fn run_xcall<CTX: GwynethContextTr>(
+    input: &[u8],
+    _gas_limit: u64,
+    ctx: &CTX,
+    caller: Address,
+) -> PrecompileResult {
+    println!("  xcalloptions_run: {}, {:?}", input.len(), input);
+
+    // Verify input length.
+    if input.len() < 83 {
+        return Err(PrecompileError::other(XCALL_INVALID_INPUT_LENGTH));
+    }
+
+    // Read the input data
+    let version = u16::from_be_bytes(input[0..2].try_into().unwrap());
+    let chain_id = u64::from_be_bytes(input[2..10].try_into().unwrap());
+    let sandbox = input[10] != 0;
+    let tx_origin: Address = (&input[11..31], chain_id).try_into().unwrap();
+    let msg_sender: Address = (&input[31..51], caller.chain_id()).try_into().unwrap();
+    let block_hash: Option<FixedBytes<32>> = Some(input[51..83].try_into().unwrap());
+    let proof = &input[83..];
+
+    // Check the version
+    if version != 1 {
+        return Err(PrecompileError::other(XCALL_INVALID_VERSION));
+    }
+
+    if !sandbox && !ctx.cfg().allow_mocking() {
+        // env.tx.caller is the Signer of the transaction
+        // caller is the address of the contract that is calling the precompile
+        if tx_origin != ctx.tx().caller() || msg_sender != caller {
+            println!(
+                "  tx_origin: {:?}, tx.caller: {:?}, msg_sender: {:?}, caller: {:?}",
+                tx_origin,
+                ctx.tx().caller(),
+                msg_sender,
+                caller
+            );
+            return Err(PrecompileError::other(XCALL_INVALID_ORIGIN));
+        }
+    }
+
+    // Set the call options
+    *ctx.chain().xcall_options = Some(XCallOptions {
+        chain_id,
+        sandbox,
+        tx_origin,
+        msg_sender,
+        block_hash,
+        proof: proof.to_vec(),
+    });
+    println!("  CallOptions: {:?}", xcall_options);
+
+    Ok(PrecompileOutput::new(
+        0,
+        Bytes::from_static(&[0x6c, 0x54, 0x13, 0x30]),
+    ))
+}


### PR DESCRIPTION
# Refactor Goal
Introduce gwyneth protocol without modifying any source files of upstream

# How
- Use the `new type pattern` of Rust to wrap the original ones. Only modify the methods for which we have different implementations; otherwise, we just pass through to the original ones.
- Add extra methods in trait by adding a new `*Ext` trait, which will only be used in gwyneth